### PR TITLE
Add flag to enable flattening of union types

### DIFF
--- a/packages/quicktype-core/src/Run.ts
+++ b/packages/quicktype-core/src/Run.ts
@@ -332,7 +332,7 @@ class Run implements RunContext {
     }
 
     private processGraph(allInputs: InputData, graphInputs: GraphInputs): TypeGraph {
-        const { targetLanguage, stringTypeMapping, conflateNumbers, flattenUnions, typeBuilder } = graphInputs;
+        const { targetLanguage, stringTypeMapping, conflateNumbers, flattenUnions: flattenUnionsFlag, typeBuilder } = graphInputs;
 
         let graph = typeBuilder.finish();
         if (this._options.debugPrintGraph) {
@@ -373,7 +373,7 @@ class Run implements RunContext {
                                 graph,
                                 stringTypeMapping,
                                 conflateNumbers,
-                                flattenUnions,
+                                flattenUnionsFlag,
                                 true,
                                 debugPrintReconstitution
                             ))
@@ -405,7 +405,7 @@ class Run implements RunContext {
                         graph,
                         stringTypeMapping,
                         conflateNumbers,
-                        flattenUnions,
+                        flattenUnionsFlag,
                         false,
                         debugPrintReconstitution
                     ))
@@ -455,7 +455,7 @@ class Run implements RunContext {
                     graph,
                     stringTypeMapping,
                     conflateNumbers,
-                    flattenUnions,
+                    flattenUnionsFlag,
                     false,
                     debugPrintReconstitution
                 ))
@@ -488,7 +488,7 @@ class Run implements RunContext {
                     graph,
                     stringTypeMapping,
                     conflateNumbers,
-                    flattenUnions,
+                    flattenUnionsFlag,
                     false,
                     debugPrintReconstitution
                 ))

--- a/packages/quicktype-core/src/Run.ts
+++ b/packages/quicktype-core/src/Run.ts
@@ -166,6 +166,8 @@ export type NonInferenceOptions = {
     debugPrintTimes: boolean;
     /** Print schema resolving steps */
     debugPrintSchemaResolving: boolean;
+    /** Will flatten union types */
+    flattenUnions: boolean;
 };
 
 export type Options = NonInferenceOptions & InferenceFlags;
@@ -187,7 +189,8 @@ const defaultOptions: NonInferenceOptions = {
     debugPrintGatherNames: false,
     debugPrintTransformations: false,
     debugPrintTimes: false,
-    debugPrintSchemaResolving: false
+    debugPrintSchemaResolving: false,
+    flattenUnions: false
 };
 
 export interface RunContext {
@@ -204,6 +207,7 @@ interface GraphInputs {
     targetLanguage: TargetLanguage;
     stringTypeMapping: StringTypeMapping;
     conflateNumbers: boolean;
+    flattenUnions: boolean;
     typeBuilder: TypeBuilder;
 }
 
@@ -280,6 +284,7 @@ class Run implements RunContext {
         const targetLanguage = getTargetLanguage(this._options.lang);
         const stringTypeMapping = this.stringTypeMapping;
         const conflateNumbers = !targetLanguage.supportsUnionsWithBothNumberTypes;
+        const flattenUnions = this._options.flattenUnions;
         const typeBuilder = new TypeBuilder(
             0,
             stringTypeMapping,
@@ -289,7 +294,7 @@ class Run implements RunContext {
             false
         );
 
-        return { targetLanguage, stringTypeMapping, conflateNumbers, typeBuilder };
+        return { targetLanguage, stringTypeMapping, conflateNumbers, flattenUnions, typeBuilder };
     }
 
     private async makeGraph(allInputs: InputData): Promise<TypeGraph> {
@@ -327,7 +332,7 @@ class Run implements RunContext {
     }
 
     private processGraph(allInputs: InputData, graphInputs: GraphInputs): TypeGraph {
-        const { targetLanguage, stringTypeMapping, conflateNumbers, typeBuilder } = graphInputs;
+        const { targetLanguage, stringTypeMapping, conflateNumbers, flattenUnions, typeBuilder } = graphInputs;
 
         let graph = typeBuilder.finish();
         if (this._options.debugPrintGraph) {
@@ -368,6 +373,7 @@ class Run implements RunContext {
                                 graph,
                                 stringTypeMapping,
                                 conflateNumbers,
+                                flattenUnions,
                                 true,
                                 debugPrintReconstitution
                             ))
@@ -399,6 +405,7 @@ class Run implements RunContext {
                         graph,
                         stringTypeMapping,
                         conflateNumbers,
+                        flattenUnions,
                         false,
                         debugPrintReconstitution
                     ))
@@ -448,6 +455,7 @@ class Run implements RunContext {
                     graph,
                     stringTypeMapping,
                     conflateNumbers,
+                    flattenUnions,
                     false,
                     debugPrintReconstitution
                 ))
@@ -480,6 +488,7 @@ class Run implements RunContext {
                     graph,
                     stringTypeMapping,
                     conflateNumbers,
+                    flattenUnions,
                     false,
                     debugPrintReconstitution
                 ))

--- a/packages/quicktype-core/src/rewrites/FlattenUnions.ts
+++ b/packages/quicktype-core/src/rewrites/FlattenUnions.ts
@@ -14,6 +14,7 @@ export function flattenUnions(
     graph: TypeGraph,
     stringTypeMapping: StringTypeMapping,
     conflateNumbers: boolean,
+    flattenUnions: boolean,
     makeObjectTypes: boolean,
     debugPrintReconstitution: boolean
 ): [TypeGraph, boolean] {
@@ -37,17 +38,35 @@ export function flattenUnions(
     let foundIntersection = false;
     const groups = makeGroupsToFlatten(nonCanonicalUnions, members => {
         messageAssert(members.size > 0, "IRNoEmptyUnions", {});
-        if (!iterableSome(members, m => m instanceof IntersectionType)) return true;
+        if (iterableSome(members, m => m instanceof IntersectionType)) {
+            // FIXME: This is stupid.  `flattenUnions` returns true when no more union
+            // flattening is necessary, but `resolveIntersections` can introduce new
+            // unions that might require flattening, so now `flattenUnions` needs to take
+            // that into account.  Either change `resolveIntersections` such that it
+            // doesn't introduce non-canonical unions (by using `unifyTypes`), or have
+            // some other way to tell whether more work is needed that doesn't require
+            // the two passes to know about each other.
+            foundIntersection = true;
+            return false;
+        }
 
-        // FIXME: This is stupid.  `flattenUnions` returns true when no more union
-        // flattening is necessary, but `resolveIntersections` can introduce new
-        // unions that might require flattening, so now `flattenUnions` needs to take
-        // that into account.  Either change `resolveIntersections` such that it
-        // doesn't introduce non-canonical unions (by using `unifyTypes`), or have
-        // some other way to tell whether more work is needed that doesn't require
-        // the two passes to know about each other.
-        foundIntersection = true;
-        return false;
+        if (
+            !flattenUnions &&
+            members.size > 1
+        ) {
+            // If the target language supports unions of classes we can avoid
+            // union flattening.
+            //
+            // FIXME: This is suboptimal because it also completely skips
+            // merging of number types based on `conflateNumbers`. The proper
+            // place for this logic would be in UnionBuilder/UnionAccumulator,
+            // but that module would have to be refactored to allow for
+            // multiple variants with the same typekind.
+            return false;
+        }
+
+        return true;
+
     });
     graph = graph.rewrite("flatten unions", stringTypeMapping, false, groups, debugPrintReconstitution, replace);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,8 @@ export interface CLIOptions {
 
     // We use this to access the inference flags
     [option: string]: any;
+
+    flattenUnions: boolean;
 }
 
 const defaultDefaultTargetLanguageName = "go";
@@ -293,7 +295,8 @@ function inferCLIOptions(opts: Partial<CLIOptions>, targetLanguage: TargetLangua
         httpMethod: opts.httpMethod,
         httpHeader: opts.httpHeader,
         debug: opts.debug,
-        telemetry: opts.telemetry
+        telemetry: opts.telemetry,
+        flattenUnions: !!opts.flattenUnions
     };
     /* tslint:enable */
     for (const flagName of inferenceFlagNames) {
@@ -324,6 +327,11 @@ function dashedFromCamelCase(name: string): string {
 
 function makeOptionDefinitions(targetLanguages: TargetLanguage[]): OptionDefinition[] {
     const beforeLang: OptionDefinition[] = [
+        {
+            name: "flatten-unions",
+            type: Boolean,
+            description: "Flatten union types to a single type."
+        },
         {
             name: "out",
             alias: "o",
@@ -885,7 +893,8 @@ export async function makeQuicktypeOptions(
         debugPrintGatherNames,
         debugPrintTransformations,
         debugPrintSchemaResolving,
-        debugPrintTimes
+        debugPrintTimes,
+        flattenUnions: options.flattenUnions
     };
     for (const flagName of inferenceFlagNames) {
         const cliName = negatedInferenceFlagName(flagName);


### PR DESCRIPTION
Adds a new flag `--flatten-unions`. Depending on how the backend DTOs are made, we sometimes would like to keep unions as enums, but sometimes just squash all the fields together.

Inspired by: https://github.com/quicktype/quicktype/pull/1460

Ticket: https://apprenticefs.atlassian.net/browse/TEM-10841

Consider this DTO:
```typescript
interface Test1 {
    type: 'no1';
    field1: string;
}

interface Test2 {
    type: 'no2';
    field2: number;
}

interface Test {
    test: Test1 | Test2;
    t1: Test1;
    t2: Test2;
}
```

without the flag set, quicktype will produce:
```swift
struct Union2DTO {
    let t1: Test1
    let t2: Test2
    let test: Test
}

// MARK: - Test1
struct Test1 {
    let field1, type: String
}

// MARK: - Test2
struct Test2 {
    let field2: Double
    let type: String
}

enum Test {
    case test1(Test1)
    case test2(Test2)
}
```
but with flag set the output will be
```swift
struct Union2DTO {
    let t1: Test1
    let t2: Test2
    let test: Test
}

// MARK: - Test1
struct Test1 {
    let field1, type: String
}

// MARK: - Test2
struct Test2 {
    let field2: Double
    let type: String
}

// MARK: - Test
struct Test {
    let field1: String?
    let type: String
    let field2: Double?
}
```
